### PR TITLE
legger til optional felt navnMottaker

### DIFF
--- a/src/main/kotlin/no/nav/helse/prosessering/v1/PdfV1Generator.kt
+++ b/src/main/kotlin/no/nav/helse/prosessering/v1/PdfV1Generator.kt
@@ -155,6 +155,7 @@ internal class PdfV1Generator {
                         "arbeidssituasjon" to melding.arbeidssituasjon.somMapUtskriftvennlig(),
                         "antallDager" to melding.antallDager,
                         "fnrMottaker" to melding.fnrMottaker,
+                        "navnMottaker" to melding.navnMottaker,
                         "medlemskap" to mapOf(
                             "har_bodd_i_utlandet_siste_12_mnd" to melding.medlemskap.harBoddIUtlandetSiste12Mnd,
                             "utenlandsopphold_siste_12_mnd" to melding.medlemskap.utenlandsoppholdSiste12Mnd.somMapUtenlandsopphold(),

--- a/src/main/kotlin/no/nav/helse/prosessering/v1/overforeDager/PreprossesertOverforeDagerV1.kt
+++ b/src/main/kotlin/no/nav/helse/prosessering/v1/overforeDager/PreprossesertOverforeDagerV1.kt
@@ -12,6 +12,7 @@ data class PreprossesertOverforeDagerV1(
     val språk: String?,
     val antallDager: Int,
     val fnrMottaker: String,
+    val navnMottaker: String?,
     val medlemskap: Medlemskap,
     val harForståttRettigheterOgPlikter: Boolean,
     val harBekreftetOpplysninger: Boolean,
@@ -34,6 +35,7 @@ data class PreprossesertOverforeDagerV1(
         harBekreftetOpplysninger = melding.harBekreftetOpplysninger,
         antallDager = melding.antallDager,
         fnrMottaker = melding.fnrMottaker,
+        navnMottaker = melding.navnMottaker,
         dokumentUrls = dokumentUrls,
         fosterbarn = melding.fosterbarn
     )

--- a/src/main/kotlin/no/nav/helse/prosessering/v1/overforeDager/SøknadOverforeDagerV1.kt
+++ b/src/main/kotlin/no/nav/helse/prosessering/v1/overforeDager/SøknadOverforeDagerV1.kt
@@ -12,6 +12,7 @@ data class SøknadOverføreDagerV1 (
     val språk: String? = "nb",
     val antallDager: Int,
     val fnrMottaker: String,
+    val navnMottaker: String?,
     val medlemskap: Medlemskap,
     val harForståttRettigheterOgPlikter: Boolean,
     val harBekreftetOpplysninger: Boolean,

--- a/src/main/resources/handlebars/soknadOverforeDager.hbs
+++ b/src/main/resources/handlebars/soknadOverforeDager.hbs
@@ -51,6 +51,9 @@
     <!-- SØKNAD -->
     <h2><span>Melding</span></h2>
     <p><b>Hvem skal dagene overføres til?</b> {{fnrMottaker}}</p>
+    {{#if navnMottaker}}
+    <p><b>Navn på den som dagene skal overføres til:</b> {{navnMottaker}}</p>
+    {{/if}}
     <p><b>Hvor mange dager skal overføres?</b> {{antallDager}}</p>
 
     <!-- Fosterbarn -->

--- a/src/test/kotlin/no/nav/helse/OmsorgspengesoknadProsesseringTest.kt
+++ b/src/test/kotlin/no/nav/helse/OmsorgspengesoknadProsesseringTest.kt
@@ -451,6 +451,7 @@ class OmsorgspengesoknadProsesseringTest {
         ),
         antallDager = 5,
         fnrMottaker = gyldigFodselsnummerB,
+        navnMottaker = "Navn På Mottaker",
         fosterbarn = listOf(
             Fosterbarn("29099012345"),
             Fosterbarn("02119970078")

--- a/src/test/kotlin/no/nav/helse/PdfV1GeneratorTest.kt
+++ b/src/test/kotlin/no/nav/helse/PdfV1GeneratorTest.kt
@@ -127,6 +127,7 @@ class PdfV1GeneratorTest {
             )
         ),
         fnrMottaker = "123456789",
+        navnMottaker = null,
         mottatt = ZonedDateTime.now(),
         søker = Søker(
             aktørId = "123456",
@@ -168,6 +169,10 @@ class PdfV1GeneratorTest {
     )
 
     private fun genererOppsummeringsPdfer(writeBytes: Boolean) {
+
+        val outputDirectory = File("out")
+        if (! outputDirectory.exists()) outputDirectory.mkdir()
+
         var id = "1-full-søknad"
         var pdf = generator.generateSoknadOppsummeringPdf(
             melding = fullGyldigMelding(soknadsId = id),
@@ -198,7 +203,7 @@ class PdfV1GeneratorTest {
 
     }
 
-    private fun pdfPath(soknadId: String) = "${System.getProperty("user.dir")}/generated-pdf-$soknadId.pdf"
+    private fun pdfPath(soknadId: String) = "${System.getProperty("user.dir")}/out/generated-pdf-$soknadId.pdf"
 
     @Test
     fun `generering av oppsummerings-PDF fungerer`() {
@@ -206,7 +211,6 @@ class PdfV1GeneratorTest {
     }
 
     @Test
-    @Ignore
     fun `opprett lesbar oppsummerings-PDF`() {
         genererOppsummeringsPdfer(true)
     }

--- a/src/test/kotlin/no/nav/helse/SøknadOverføreDagerFormatTest.kt
+++ b/src/test/kotlin/no/nav/helse/SøknadOverføreDagerFormatTest.kt
@@ -34,6 +34,7 @@ class SøknadOverføreDagerFormatTest {
                   },
                   "antallDager": 10,
                   "fnrMottaker": "123456789",
+                  "navnMottaker": "Navn På Mottaker",
                   "medlemskap": {
                     "harBoddIUtlandetSiste12Mnd": true,
                     "utenlandsoppholdSiste12Mnd": [],
@@ -76,6 +77,7 @@ class SøknadOverføreDagerFormatTest {
         harForståttRettigheterOgPlikter = true,
         antallDager = 10,
         fnrMottaker = "123456789",
+        navnMottaker = "Navn På Mottaker",
         fosterbarn = listOf(
             Fosterbarn("123456789")
         )


### PR DESCRIPTION
Feltet er lagt til som optional fordi backend må prodsettes før frontend for å unngå at navnet ikke blir med på pdf, mens etter prodsetting av backend så vil noen brukere ha gammel frontend frem til frontend blir deployet. Gammel frontend vil ikke ha feltet navnMottaker