### PR TITLE
Konfigurer auto.offset.reset som none.

### DIFF
--- a/nais/dev-fss.json
+++ b/nais/dev-fss.json
@@ -21,7 +21,8 @@
     "LAGRE_DOKUMENT_SCOPES": "97f0b1bc-6aa9-4d44-a3c7-60b4318fbec4/.default",
     "SLETTE_DOKUMENT_SCOPES": "97f0b1bc-6aa9-4d44-a3c7-60b4318fbec4/.default",
     "JOURNALFORE_SCOPES": "b32ae17c-0276-4006-9507-4ef49e0e5e20/.default",
-    "KAFKA_BOOTSTRAP_SERVERS": "b27apvl00045.preprod.local:8443,b27apvl00046.preprod.local:8443,b27apvl00047.preprod.local:8443"
+    "KAFKA_BOOTSTRAP_SERVERS": "b27apvl00045.preprod.local:8443,b27apvl00046.preprod.local:8443,b27apvl00047.preprod.local:8443",
+    "KAFKA_AUTO_OFFSET_RESET": "none"
   },
   "slack-channel": "sif-alerts-dev",
   "slack-notify-type": "<!here> | omsorgspengesoknad-prosessering | "

--- a/nais/prod-fss.json
+++ b/nais/prod-fss.json
@@ -21,7 +21,8 @@
     "LAGRE_DOKUMENT_SCOPES": "0c5a6709-ba2a-42b7-bbfc-9b9f844e2ee2/.default",
     "SLETTE_DOKUMENT_SCOPES": "0c5a6709-ba2a-42b7-bbfc-9b9f844e2ee2/.default",
     "JOURNALFORE_SCOPES": "cb751642-883c-48d3-9f82-06cc72c3e4b9/.default",
-    "KAFKA_BOOTSTRAP_SERVERS": "a01apvl00145.adeo.no:8443,a01apvl00146.adeo.no:8443,a01apvl00147.adeo.no:8443,a01apvl00148.adeo.no:8443,a01apvl00149.adeo.no:8443,a01apvl00150.adeo.no:8443"
+    "KAFKA_BOOTSTRAP_SERVERS": "a01apvl00145.adeo.no:8443,a01apvl00146.adeo.no:8443,a01apvl00147.adeo.no:8443,a01apvl00148.adeo.no:8443,a01apvl00149.adeo.no:8443,a01apvl00150.adeo.no:8443",
+    "KAFKA_AUTO_OFFSET_RESET": "none"
   },
   "slack-channel": "sif-alerts",
   "slack-notify-type": "<!channel> | omsorgspengesoknad-prosessering | "

--- a/src/main/kotlin/no/nav/helse/kafka/KafkaConfig.kt
+++ b/src/main/kotlin/no/nav/helse/kafka/KafkaConfig.kt
@@ -20,12 +20,13 @@ internal class KafkaConfig(
     credentials: Pair<String, String>,
     trustStore: Pair<String, String>?,
     exactlyOnce: Boolean,
+    autoOffsetReset: String,
     internal val unreadyAfterStreamStoppedIn: Duration
 ) {
     private val streams = Properties().apply {
         put(BOOTSTRAP_SERVERS_CONFIG, bootstrapServers)
         put(DEFAULT_DESERIALIZATION_EXCEPTION_HANDLER_CLASS_CONFIG, LogAndFailExceptionHandler::class.java)
-        put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
+        put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, autoOffsetReset)
         medCredentials(credentials)
         medTrustStore(trustStore)
         medProcessingGuarantee(exactlyOnce)

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -51,6 +51,8 @@ nav {
         username = ${?NAIS_username}
         password = ""
         password = ${?NAIS_password},
+        auto_offset_reset = ""
+        auto_offset_reset = ${?KAFKA_AUTO_OFFSET_RESET}
         unready_after_stream_stopped_in = {
             amount = "15"
             unit = "MINUTES"

--- a/src/test/kotlin/no/nav/helse/TestConfiguration.kt
+++ b/src/test/kotlin/no/nav/helse/TestConfiguration.kt
@@ -49,6 +49,7 @@ object TestConfiguration {
             map["nav.kafka.bootstrap_servers"] = it.brokersURL
             map["nav.kafka.username"] = it.username()
             map["nav.kafka.password"] = it.password()
+            map["nav.kafka.auto_offset_reset"] = "earliest"
         }
 
         return map.toMap()


### PR DESCRIPTION
Vil gi en exception dersom kafka server ikke finner offset for consumer.
Dette hindrer consumer fra å hoppe til latest eller earliest offset dersom kafkaserver ikke skulle offset for consumer.