### PR TITLE
Setter kafka-auto-offset-reset til earliest i prod.

### DIFF
--- a/nais/prod-fss.json
+++ b/nais/prod-fss.json
@@ -22,7 +22,7 @@
     "SLETTE_DOKUMENT_SCOPES": "0c5a6709-ba2a-42b7-bbfc-9b9f844e2ee2/.default",
     "JOURNALFORE_SCOPES": "cb751642-883c-48d3-9f82-06cc72c3e4b9/.default",
     "KAFKA_BOOTSTRAP_SERVERS": "a01apvl00145.adeo.no:8443,a01apvl00146.adeo.no:8443,a01apvl00147.adeo.no:8443,a01apvl00148.adeo.no:8443,a01apvl00149.adeo.no:8443,a01apvl00150.adeo.no:8443",
-    "KAFKA_AUTO_OFFSET_RESET": "none"
+    "KAFKA_AUTO_OFFSET_RESET": "earliest"
   },
   "slack-channel": "sif-alerts",
   "slack-notify-type": "<!channel> | omsorgspengesoknad-prosessering | "

--- a/src/main/kotlin/no/nav/helse/Configuration.kt
+++ b/src/main/kotlin/no/nav/helse/Configuration.kt
@@ -27,6 +27,7 @@ data class Configuration(private val config : ApplicationConfig) {
     )
 
     internal fun soknadDatoMottattEtter() = ZonedDateTime.parse(config.getRequiredString("nav.prosesser_soknader_mottatt_etter", secret = false))
+    internal fun soknadDatoMottattEtterCleanup() = ZonedDateTime.parse(config.getRequiredString("nav.cleanup_soknader_mottatt_etter", secret = false))
 
     internal fun getKafkaConfig() = config.getRequiredString("nav.kafka.bootstrap_servers", secret = false).let { bootstrapServers ->
         val trustStore = config.getOptionalString("nav.trust_store.path", secret = false)?.let { trustStorePath ->

--- a/src/main/kotlin/no/nav/helse/OmsorgspengesoknadProsessering.kt
+++ b/src/main/kotlin/no/nav/helse/OmsorgspengesoknadProsessering.kt
@@ -100,7 +100,8 @@ fun Application.omsorgspengesoknadProsessering() {
         preprosseseringV1Service = preprosseseringV1Service,
         joarkGateway = joarkGateway,
         dokumentService = dokumentService,
-        datoMottattEtter = configuration.soknadDatoMottattEtter()
+        datoMottattEtter = configuration.soknadDatoMottattEtter(),
+        datoMottattEtterCleanup = configuration.soknadDatoMottattEtterCleanup()
     )
 
     environment.monitor.subscribe(ApplicationStopping) {

--- a/src/main/kotlin/no/nav/helse/prosessering/v1/asynkron/AsynkronProsesseringV1Service.kt
+++ b/src/main/kotlin/no/nav/helse/prosessering/v1/asynkron/AsynkronProsesseringV1Service.kt
@@ -13,7 +13,8 @@ internal class AsynkronProsesseringV1Service(
     preprosseseringV1Service: PreprosseseringV1Service,
     joarkGateway: JoarkGateway,
     dokumentService: DokumentService,
-    datoMottattEtter: ZonedDateTime
+    datoMottattEtter: ZonedDateTime,
+    datoMottattEtterCleanup: ZonedDateTime
 ) {
 
     private companion object {
@@ -36,7 +37,7 @@ internal class AsynkronProsesseringV1Service(
     private val cleanupStream = CleanupStream(
         kafkaConfig = kafkaConfig,
         dokumentService = dokumentService,
-        søknadMottattEtter = datoMottattEtter
+        søknadMottattEtter = datoMottattEtterCleanup
     )
 
     private val healthChecks = setOf(

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -9,8 +9,10 @@ ktor {
     }
 }
 nav {
-    prosesser_soknader_mottatt_etter = "2020-11-05T00:00:00.000+01"
+    prosesser_soknader_mottatt_etter = "2021-01-19T10:00:00.000+01"
     prosesser_soknader_mottatt_etter = ${?PROSESSER_SOKNADER_MOTTATT_ETTER}
+    cleanup_soknader_mottatt_etter = "2021-01-19T05:00:00.000+01"
+    cleanup_soknader_mottatt_etter = ${?CLEANUP_SOKNADER_MOTTATT_ETTER}
     k9_dokument_base_url = ""
     k9_dokument_base_url = ${?K9_DOKUMENT_BASE_URL}
     K9_JOARK_BASE_URL = ""


### PR DESCRIPTION
Siste melding som ble vellyket sendt gjennom cleanup er 18/1 18:55. Neste søknaden som gikk gjennom journalføring men feilet i cleanup er 19/1 05:17. Ønsker altså at cleanup skal prosessere fra og med den søknaden. Siste søknaden som gikk gjennom preprosessering og journalføring er 19/1 09:14, har ikke kommet noen etter det. Vil altså at preprosessering og journalføring skal prosessere alle søknader som kommer etter 10:00.

Mangler totalt 5 søknader som ikke har vært gjennom cleanup.

Logg som viser søknader sendt inn via api: [HER](https://logs.adeo.no/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-2d,to:now))&_a=(columns:!(message,envclass,level,application,host),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'96e648c0-980a-11e9-830a-e17bbd64b4db',key:envclass,negate:!f,params:(query:p),type:phrase),query:(match_phrase:(envclass:p))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'96e648c0-980a-11e9-830a-e17bbd64b4db',key:message,negate:!f,params:(query:'202%20Accepted:%20POST%20-%20%2Fsoknad'),type:phrase),query:(match_phrase:(message:'202%20Accepted:%20POST%20-%20%2Fsoknad')))),index:'96e648c0-980a-11e9-830a-e17bbd64b4db',interval:auto,query:(language:lucene,query:'application:omsorgspenger-api'),sort:!(!('@timestamp',desc))))

Logg som viser søknader som har gått gjennom cleanup: [HER](https://logs.adeo.no/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-2d,to:now))&_a=(columns:!(message,envclass,level,application,host),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'96e648c0-980a-11e9-830a-e17bbd64b4db',key:envclass,negate:!f,params:(query:p),type:phrase),query:(match_phrase:(envclass:p))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'96e648c0-980a-11e9-830a-e17bbd64b4db',key:message,negate:!f,params:(query:'Videresender%20journalf%C3%B8rt%20melding'),type:phrase),query:(match_phrase:(message:'Videresender%20journalf%C3%B8rt%20melding')))),index:'96e648c0-980a-11e9-830a-e17bbd64b4db',interval:auto,query:(language:lucene,query:'application:omsorgspengesoknad-prosessering'),sort:!(!('@timestamp',desc))))

Logg som viser søknader som har gått gjennom journalføring: [HER](https://logs.adeo.no/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-2d,to:now))&_a=(columns:!(message,envclass,level,application,host),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'96e648c0-980a-11e9-830a-e17bbd64b4db',key:envclass,negate:!f,params:(query:p),type:phrase),query:(match_phrase:(envclass:p))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'96e648c0-980a-11e9-830a-e17bbd64b4db',key:message,negate:!f,params:(query:'Dokumenter%20journalf%C3%B8rt%20med%20ID%20%3D%20'),type:phrase),query:(match_phrase:(message:'Dokumenter%20journalf%C3%B8rt%20med%20ID%20%3D%20')))),index:'96e648c0-980a-11e9-830a-e17bbd64b4db',interval:auto,query:(language:lucene,query:'application:omsorgspengesoknad-prosessering'),sort:!(!('@timestamp',desc))))